### PR TITLE
Fixed Bug with Converting Code to JAR

### DIFF
--- a/states/GameState.java
+++ b/states/GameState.java
@@ -16,7 +16,7 @@ public class GameState extends State{
 	
 	public GameState(Handler handler) {
 		super(handler);
-		world = new World(handler, "res/worlds/world1.txt");
+		world = new World(handler, "worlds/world1.txt");
 		handler.setWorld(world);
 		player = new Player(handler, 100, 100);
 		

--- a/utils/Utils.java
+++ b/utils/Utils.java
@@ -3,13 +3,17 @@ package utils;
 import java.io.BufferedReader;
 import java.io.FileReader;
 import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
 public class Utils {
 	
 	public static String loadFileAsString(String path) {
 		StringBuilder builder = new StringBuilder();
 		
 		try {
-			BufferedReader br = new BufferedReader(new FileReader(path));
+			InputStream is = Thread.currentThread().getContextClassLoader().getResourceAsStream(path);
+;			BufferedReader br = new BufferedReader(new InputStreamReader(is));
 			String line;
 			while((line = br.readLine()) != null) {
 				builder.append(line + "\n");


### PR DESCRIPTION
There was an issue when converting the code to a runnable JAR file for release, that the world text file wasn't seen by the JAR file. So changed the Utils class from using FileReader to InputStreamReader.  The game works fine on my end and when you export the project as a runnable jar file the game works.
This will help us when publishing a release.